### PR TITLE
Upgrade gradle to 7.0.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
With the gradle version 7.0.3 **databinding-adapters** does not work

This is the error:

```
Execution failed for task ':app:processDebugResources'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Failed to transform databinding-adapters-7.0.3.aar (androidx.databinding:databinding-adapters:7.0.3) to match attributes {artifactType=android-compiled-dependencies-resources, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=aar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Could not isolate parameters com.android.build.gradle.internal.dependency.AarResourcesCompilerTransform$Parameters_Decorated@629fa9dd of artifact transform AarResourcesCompilerTransform
         > Could not isolate value com.android.build.gradle.internal.dependency.AarResourcesCompilerTransform$Parameters_Decorated@629fa9dd of type AarResourcesCompilerTransform.Parameters
            > Could not resolve all files for configuration ':app:detachedConfiguration1'.
               > Failed to transform aapt2-7.0.3-7396180-windows.jar (com.android.tools.build:aapt2:7.0.3-7396180) to match attributes {artifactType=_internal-android-aapt2-binary, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}.
                  > Could not find aapt2-7.0.3-7396180-windows.jar (com.android.tools.build:aapt2:7.0.3-7396180).
                    Searched in the following locations:
                        https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/7.0.3-7396180/aapt2-7.0.3-7396180-windows.jar
   > Failed to transform databinding-ktx-7.0.3.aar (androidx.databinding:databinding-ktx:7.0.3) to match attributes {artifactType=android-compiled-dependencies-resources, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=aar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Could not isolate parameters com.android.build.gradle.internal.dependency.AarResourcesCompilerTransform$Parameters_Decorated@629fa9dd of artifact transform AarResourcesCompilerTransform
         > Could not isolate value com.android.build.gradle.internal.dependency.AarResourcesCompilerTransform$Parameters_Decorated@629fa9dd of type AarResourcesCompilerTransform.Parameters
            > Could not resolve all files for configuration ':app:detachedConfiguration1'.
               > Failed to transform aapt2-7.0.3-7396180-windows.jar (com.android.tools.build:aapt2:7.0.3-7396180) to match attributes {artifactType=_internal-android-aapt2-binary, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}.
                  > Could not find aapt2-7.0.3-7396180-windows.jar (com.android.tools.build:aapt2:7.0.3-7396180).
                    Searched in the following locations:
                        https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/7.0.3-7396180/aapt2-7.0.3-7396180-windows.jar

```

My solution was to update the gradle version to 7.0.4

I hope this minimal contribution is of some use, greetings