### PR TITLE
Prevent duplication by excluding lifecycle-viewmodel-ktx in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.31"
+    ext.kotlin_version = "1.6.21"
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,12 @@ buildscript {
     }
 }
 
+configurations {
+    all {
+        exclude group: 'androidx.lifecycle', module: 'lifecycle-viewmodel-ktx'
+    }
+}
+
 allprojects {
     repositories {
         google()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Oct 16 16:33:22 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip


### PR DESCRIPTION
- Prevent duplication by excluding lifecycle-viewmodel-ktx in build.gradle
    - This eliminates an unnecessary AndroidX lifecycle library that was causing build errors. The exclusion also helps in reducing the memory footprint by removing redundant classes, thus optimizing overall performance
- Update Gradle & Kotlin versions